### PR TITLE
* fixed signed<->unsigned comparison warning

### DIFF
--- a/wjson/serializer/string.hpp
+++ b/wjson/serializer/string.hpp
@@ -136,7 +136,7 @@ private:
     else
       ss << "\\x" << std::setfill('0') << std::setw(2) << std::hex << static_cast<unsigned int>(static_cast<unsigned char>(*beg));
 
-    for (int i=0; i < bufsize && buf[i]!='\0'; ++i)
+    for (size_t i=0; i < bufsize && buf[i]!='\0'; ++i)
       *(itr++) = buf[i];
     return ++beg;
   }


### PR DESCRIPTION
Привет!

Поправил warning
wjson/wjson/serializer/string.hpp:139:21: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
     for (int i=0; i < bufsize && buf[i]!='\0'; ++i)