### PR TITLE
Fixed special symbols escaping.

### DIFF
--- a/wjson/serializer/string.hpp
+++ b/wjson/serializer/string.hpp
@@ -33,11 +33,10 @@ public:
 
     for (;beg!=end && ( !NullTerm || *beg!='\0' ) ;)
     {
-      if ( static_cast<unsigned char>(*beg) >=32 && static_cast<unsigned char>(*beg) < 127 )
-      {
-        *(itr++) = *(beg++);
-      }
-      else if ( static_cast<unsigned char>(*beg) < 32 ) 
+      if ( static_cast<unsigned char>(*beg) < 32 ||
+           static_cast<unsigned char>(*beg) == '"' || 
+           static_cast<unsigned char>(*beg) == '\\' || 
+           static_cast<unsigned char>(*beg) == '/') 
       {
         switch (*beg)
         {
@@ -56,6 +55,10 @@ public:
         }
         ++beg;
       } 
+      else if ( static_cast<unsigned char>(*beg) >=32 && static_cast<unsigned char>(*beg) < 127 )
+      {
+        *(itr++) = *(beg++);
+      }
       else if ( parser::is_utf8(beg, end) )
       {
         json_error e;


### PR DESCRIPTION
Some of the special characters have values greater than 127 and therefore they were processed in the wrong if-else branch.